### PR TITLE
Small artwork generator refactor and better file name generation

### DIFF
--- a/pages/artwork-generator.tsx
+++ b/pages/artwork-generator.tsx
@@ -5,7 +5,7 @@ import Button from "../components/ui/Button";
 import NextImage from "next/image";
 import dayjs from "dayjs";
 import ColorLogo from "../icons/ColorLogo";
-import { download, getMeta } from "../util";
+import { domElToImage, getMeta } from "../util";
 
 export default function ThumbnailGenerator() {
   const thumbnail = useRef<HTMLDivElement | null>(null);
@@ -57,13 +57,17 @@ export default function ThumbnailGenerator() {
     }
   }, [zoom]);
 
-  function handleDownload() {
+  function handleImageDownload(artists: string, title: string, dateTime: Date) {
     if (!title || !artists || !dateTime) {
       setError("The fields Title, Artists and Date and Time are required");
       return;
     }
     setError(null);
-    download(thumbnail.current);
+
+    const fileName = [title, artists].join("_") + "-"
+    + dayjs(dateTime).format("DDMMYYYY") + "-" + aspectRatio
+
+    domElToImage(thumbnail.current, fileName)
   }
 
   return (
@@ -332,7 +336,7 @@ export default function ThumbnailGenerator() {
             </div>
 
             <div className="text-black mb-4">
-              <Button onClick={handleDownload}>Download Jpeg</Button>
+              <Button onClick={() => handleImageDownload(artists, title, dateTime)}>Download</Button>
               <p className="text-white mt-4">* Required field</p>
               {error && (
                 <p className="text-white bg-red-600 border-red-400 border rounded-md p-2 mt-4">

--- a/util.ts
+++ b/util.ts
@@ -63,7 +63,7 @@ export const getMeta = async (url: string) => {
   return img;
 };
 
-export function download(element: HTMLDivElement) {
+export function domElToImage(element: HTMLDivElement, fileName?: string) {
   domtoimage
     .toJpeg(element, {
       style: {
@@ -80,7 +80,7 @@ export function download(element: HTMLDivElement) {
         })
         .then((dataUrl) => {
           const link = document.createElement("a");
-          link.download = "oroko-thumbnail.jpeg";
+          link.download = fileName ? fileName : "oroko-thumbnail.jpeg";
           link.href = dataUrl;
           link.click();
         });


### PR DESCRIPTION
Hello!

I wanted to make a small contribution to the repo to address a small annoyance I've had as a resident for the last year haha. The goal of this pull request is to automatically generate a file name for the image based on the information input by the user. The default `oroko-thumbnail.jpg` file was undescriptive would result in file name collisions regardless of what the user input. Now it generates a file name based on the information also considers the aspect ratio to avoid duplicate file names for different sizes

Let me know what you think about this contribution, thanks :)

Before:
![image](https://github.com/user-attachments/assets/956526f6-bda6-44ac-a272-6de5714267a2)

After:
![image](https://github.com/user-attachments/assets/5aabce37-deae-4e65-bcbb-83707c1a7030)

